### PR TITLE
feat: 주의사항 디자인 변경에 따른 추가 로직 수정

### DIFF
--- a/src/components/Textarea/index.tsx
+++ b/src/components/Textarea/index.tsx
@@ -93,7 +93,7 @@ const StyledTextarea = styled.textarea<{ variant: TextareaVariant }>`
     ${({ variant }) => {
         switch (variant) {
             case "flat-sm":
-                return `min-height: 77px;`;
+                return `height: 77px;`;
             case "flat":
                 return `min-height: 120px;`;
             case "flat-lg":

--- a/src/pages/owner/Recruit/RecruitPrecautionPage.tsx
+++ b/src/pages/owner/Recruit/RecruitPrecautionPage.tsx
@@ -17,7 +17,7 @@ export default function RecruitPrecautionPage({ formData, setFormData, onSubmit 
         <>
             <Header title="주의사항 작성" showBackButton />
             <PageWrapper hasHeader>
-                <Wrapper.FlexBox direction="column" padding="30px 15px" gap="6px">
+                <Wrapper.FlexBox direction="column" padding="30px" gap="20px">
                     <Wrapper.FlexBox height="50px" direction="column" alignItems="center">
                         <Text.Body3_1 color="Gray4">스탭에게 전달하고 싶은 주의사항을 작성해주세요.</Text.Body3_1>
                         <Text.Body3_1 color="Gray4">스탭 합격시 메세지를 통하여 보여지게 됩니다.</Text.Body3_1>
@@ -27,11 +27,9 @@ export default function RecruitPrecautionPage({ formData, setFormData, onSubmit 
                         values={formData.precautions}
                         onChange={updated => setFormData(prev => ({ ...prev, precautions: updated }))}
                     />
-                    <Wrapper.FlexBox padding="0 15px" margin="20px 0 0 0">
-                        <Button label="작성 완료" width="large" onClick={onSubmit}>
-                            작성 완료
-                        </Button>
-                    </Wrapper.FlexBox>
+                    <Button label="작성 완료" width="large" onClick={onSubmit}>
+                        작성 완료
+                    </Button>
                 </Wrapper.FlexBox>
             </PageWrapper>
         </>

--- a/src/pages/owner/components/PrecautionListItem.tsx
+++ b/src/pages/owner/components/PrecautionListItem.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import styled from "@emotion/styled";
 import { Wrapper } from "@/styles/Wrapper";
 import theme from "@/styles/theme";
+import { Text } from "@/styles/Text";
 
 type Precaution = {
     precautionsTitle: string;
@@ -28,48 +29,66 @@ export default function PrecautionItem({ values, onChange }: PrecautionListEdito
     };
 
     const handleRemovePrecaution = (index: number) => {
+        if (values.length <= 2) return;
         const updated = values.filter((_, i) => i !== index);
-        onChange(updated.length === 0 ? [{ precautionsTitle: "", precautionsContent: "" }] : updated);
+        onChange(updated);
     };
 
     useEffect(() => {
-        if (values.length === 0) {
-            onChange([{ precautionsTitle: "", precautionsContent: "" }]);
+        if (values.length < 2) {
+            const toAdd = 2 - values.length;
+            const newItems = Array(toAdd).fill({ precautionsTitle: "", precautionsContent: "" });
+            onChange([...values, ...newItems]);
         }
     }, [values, onChange]);
 
     return (
         <>
-            {values.map((item, index) => (
-                <Style.InputGroup key={index}>
-                    <Input
-                        inputTitle="제목"
-                        placeholder="ex) 일과 재미, 균형 잡기! ⚖️"
-                        variant="default"
-                        value={item.precautionsTitle}
-                        onChange={e => handleChangePrecaution({ ...item, precautionsTitle: e.target.value }, index)}
-                    />
-                    <Textarea
-                        textareaTitle="내용"
-                        placeholder="ex) 즐길 때는 확실히! 하지만 업무 시간엔 프로페셔널하게 행동해 주세요."
-                        variant="flat-sm"
-                        value={item.precautionsContent}
-                        onChange={e => handleChangePrecaution({ ...item, precautionsContent: e.target.value }, index)}
-                    />
-                    {values.length > 1 && (
-                        <Style.DeleteBoxButton
-                            src="/icons/deleteTag.svg"
-                            alt="삭제"
-                            onClick={() => handleRemovePrecaution(index)}
+            {values.map((item, index) => {
+                const isDeletable = values.length > 2;
+                const isLastItem = index === values.length - 1;
+                return (
+                    <Style.InputGroup key={index} isLast={isLastItem}>
+                        <Style.HeaderRow>
+                            <Text.Title3_1>
+                                주의사항 {index + 1}
+                                {index < 2 && <Style.Required>*</Style.Required>}
+                            </Text.Title3_1>
+
+                            {isDeletable && (
+                                <Style.DeleteBoxButton
+                                    src="/icons/deleteTag.svg"
+                                    alt="삭제"
+                                    onClick={() => handleRemovePrecaution(index)}
+                                />
+                            )}
+                        </Style.HeaderRow>
+
+                        <Input
+                            inputTitle="제목"
+                            placeholder="ex) 일과 재미, 균형 잡기! ⚖️"
+                            variant="default"
+                            value={item.precautionsTitle}
+                            onChange={e => handleChangePrecaution({ ...item, precautionsTitle: e.target.value }, index)}
                         />
-                    )}
-                </Style.InputGroup>
-            ))}
+                        <Textarea
+                            textareaTitle="소개글"
+                            placeholder="ex) 즐길 때는 확실히! 하지만 업무 시간엔 프로페셔널하게 행동해 주세요."
+                            variant="flat-sm"
+                            value={item.precautionsContent}
+                            onChange={e =>
+                                handleChangePrecaution({ ...item, precautionsContent: e.target.value }, index)
+                            }
+                        />
+                    </Style.InputGroup>
+                );
+            })}
+
             {values.length < 5 && (
-                <Wrapper.FlexBox justifyContent="center" margin="15px 0 0 0">
+                <Wrapper.FlexBox justifyContent="center">
                     <Style.AddPrecaution
                         src="/icons/addMainColor.svg"
-                        alt="복리후생 추가 버튼"
+                        alt="주의사항 추가 버튼"
                         onClick={handleAddPrecaution}
                     />
                 </Wrapper.FlexBox>
@@ -79,31 +98,32 @@ export default function PrecautionItem({ values, onChange }: PrecautionListEdito
 }
 
 const Style = {
-    InputGroup: styled.div`
+    InputGroup: styled.div<{ isLast: boolean }>`
         position: relative;
         width: 100%;
         display: flex;
         flex-direction: column;
-        gap: 8px;
-        padding: 15px;
-        border-radius: 8px;
-        transition:
-            background-color 0.2s ease,
-            box-shadow 0.2s ease;
-        &:hover {
-            background-color: ${theme.color.Gray1};
-            box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
-        }
+        gap: 12px;
+        padding-bottom: 20px;
+        border-bottom: ${({ isLast }) => (isLast ? "none" : `1px solid ${theme.color.Gray1}`)};
     `,
+
+    HeaderRow: styled.div`
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+    `,
+
+    Required: styled.span`
+        color: ${theme.color.Main};
+        margin-left: 4px;
+    `,
+
     DeleteBoxButton: styled.img`
-        position: absolute;
-        top: 12px;
-        right: 12px;
         width: 20px;
         height: 20px;
         background: #ccc;
         border-radius: 50%;
-
         cursor: pointer;
     `,
     AddPrecaution: styled.img`


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요 (이미지 첨부 가능)

이전 
<img src="https://github.com/user-attachments/assets/91eb8198-ff35-45f1-9148-69f58e41f76c" width="300" />



이후
 
<img src="https://github.com/user-attachments/assets/2577ee6c-dfe4-4991-82aa-e615e452b4c3" width="300" />
<img src="https://github.com/user-attachments/assets/0aaf3263-c11d-4436-a4b9-26e8235adff6" width="300" />

 
## 💬 리뷰 요구사항 (선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

디자이너님께서는 1, 2번째 주의사항 항목에는 삭제 버튼이 보이지 않고, 이후에 추가되는 항목들에만 삭제 버튼이 보이도록 요청하셨습니다. 하지만 이렇게 되면 이미 작성된 1번이나 2번 항목을 삭제하고 싶은 경우 불편할 수 있다고 생각해 주의사항이 3개 이상일 때는 모든 항목에 삭제 버튼이 보이도록 했고, 대신 화면에 표시된 항목이 2개 이하일 경우에는 삭제 버튼이 아예 안 보이게 처리했습니다.

## #️⃣ 해당 작업과 연관된 이슈

> ex. #이슈번호, #이슈번호
#20 