### PR TITLE
refactor: React Query 전역 에러 핸들링 통합

### DIFF
--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -1,0 +1,34 @@
+import { QueryCache, MutationCache, QueryClient } from "@tanstack/react-query";
+import { AxiosError } from "axios";
+import { errorMessages } from "@/constants/errorMessages";
+
+function getErrorMessage(error: unknown): string {
+    if (error instanceof AxiosError) {
+        const status = error.response?.status;
+        const bodyStatus = error.response?.data?.status;
+
+        if (status && bodyStatus && errorMessages[bodyStatus]) {
+            return errorMessages[bodyStatus];
+        }
+
+        if (status && errorMessages[status]) {
+            return errorMessages[status];
+        }
+    }
+    return "알 수 없는 오류가 발생했어요. 잠시 후 다시 시도해주세요.";
+}
+
+export const queryClient = new QueryClient({
+    queryCache: new QueryCache({
+        onError: error => {
+            // TODO: 모달 컴포넌트
+            console.error("에러상위통합처리", getErrorMessage(error));
+        },
+    }),
+    mutationCache: new MutationCache({
+        onError: error => {
+            // TODO: 모달 컴포넌트
+            console.error("에러상위통합처리", getErrorMessage(error));
+        },
+    }),
+});

--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -1,6 +1,7 @@
 import { QueryCache, MutationCache, QueryClient } from "@tanstack/react-query";
 import { AxiosError } from "axios";
 import { errorMessages } from "@/constants/errorMessages";
+import { useErrorStore } from "@/store/useErrorStore";
 
 function getErrorMessage(error: unknown): string {
     if (error instanceof AxiosError) {
@@ -21,14 +22,16 @@ function getErrorMessage(error: unknown): string {
 export const queryClient = new QueryClient({
     queryCache: new QueryCache({
         onError: error => {
-            // TODO: 모달 컴포넌트
-            console.error("에러상위통합처리", getErrorMessage(error));
+            const message = getErrorMessage(error);
+            useErrorStore.getState().showError(message);
+            console.error("에러상위통합처리", message);
         },
     }),
     mutationCache: new MutationCache({
         onError: error => {
-            // TODO: 모달 컴포넌트
-            console.error("에러상위통합처리", getErrorMessage(error));
+            const message = getErrorMessage(error);
+            useErrorStore.getState().showError(message);
+            console.error("에러상위통합처리", message);
         },
     }),
 });

--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -21,14 +21,20 @@ function getErrorMessage(error: unknown): string {
 
 export const queryClient = new QueryClient({
     queryCache: new QueryCache({
-        onError: error => {
+        onError: (error, query) => {
+            if (query?.meta && (query.meta as { suppressGlobalError?: boolean }).suppressGlobalError) {
+                return;
+            }
             const message = getErrorMessage(error);
             useErrorStore.getState().showError(message);
             console.error("에러상위통합처리", message);
         },
     }),
     mutationCache: new MutationCache({
-        onError: error => {
+        onError: (error, _variables, _context, mutation) => {
+            if (mutation?.meta && (mutation.meta as { suppressGlobalError?: boolean }).suppressGlobalError) {
+                return;
+            }
             const message = getErrorMessage(error);
             useErrorStore.getState().showError(message);
             console.error("에러상위통합처리", message);

--- a/src/apis/queryClient.ts
+++ b/src/apis/queryClient.ts
@@ -8,6 +8,8 @@ function getErrorMessage(error: unknown): string {
         const status = error.response?.status;
         const bodyStatus = error.response?.data?.status;
 
+        if (status === 401 || status === 419) return "";
+
         if (status && bodyStatus && errorMessages[bodyStatus]) {
             return errorMessages[bodyStatus];
         }
@@ -26,6 +28,7 @@ export const queryClient = new QueryClient({
                 return;
             }
             const message = getErrorMessage(error);
+            if (!message) return;
             useErrorStore.getState().showError(message);
             console.error("에러상위통합처리", message);
         },

--- a/src/components/ErrorWatcher.tsx
+++ b/src/components/ErrorWatcher.tsx
@@ -1,0 +1,23 @@
+import Modal from "@/components/Modal";
+import { useErrorStore } from "@/store/useErrorStore";
+
+export default function ErrorWatcher() {
+    const isOpen = useErrorStore(state => state.isOpen);
+    const message = useErrorStore(state => state.message);
+    const clearError = useErrorStore(state => state.clearError);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    return (
+        <Modal
+            variant="error"
+            title="오류가 발생했어요"
+            message={message}
+            confirmText="확인"
+            handleModalClose={clearError}
+            onConfirm={clearError}
+        />
+    );
+}

--- a/src/components/ErrorWatcher.tsx
+++ b/src/components/ErrorWatcher.tsx
@@ -1,14 +1,25 @@
 import Modal from "@/components/Modal";
 import { useErrorStore } from "@/store/useErrorStore";
+import { useNavigate } from "react-router-dom";
 
 export default function ErrorWatcher() {
     const isOpen = useErrorStore(state => state.isOpen);
     const message = useErrorStore(state => state.message);
     const clearError = useErrorStore(state => state.clearError);
+    const navigate = useNavigate();
 
-    if (!isOpen) {
-        return null;
-    }
+    if (!isOpen) return null;
+
+    const handleClose = () => {
+        if (
+            message.includes("요청한 데이터를 찾을 수 없습니다") ||
+            message.includes("서버 오류") ||
+            message.includes("찾을 수 없")
+        ) {
+            navigate("/", { replace: true });
+        }
+        clearError();
+    };
 
     return (
         <Modal
@@ -16,8 +27,8 @@ export default function ErrorWatcher() {
             title="오류가 발생했어요"
             message={message}
             confirmText="확인"
-            handleModalClose={clearError}
-            onConfirm={clearError}
+            handleModalClose={handleClose}
+            onConfirm={handleClose}
         />
     );
 }

--- a/src/constants/errorMessages.ts
+++ b/src/constants/errorMessages.ts
@@ -1,0 +1,19 @@
+export const errorMessages: Record<string | number, string> = {
+    // HTTP 코드
+    401: "로그인이 필요합니다.",
+    403: "권한이 없습니다.",
+    404: "요청한 데이터를 찾을 수 없습니다.",
+    409: "이미 처리된 요청입니다.",
+    500: "서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+
+    // body.status
+    REQUEST_VALIDATION_ERROR: "입력값이 올바르지 않습니다.",
+    REQUEST_BODY_ERROR: "요청 형식이 잘못되었습니다.",
+    MULTIPART_ERROR: "파일 업로드에 실패했습니다. (20MB 제한)",
+    NEED_LOGIN: "로그인이 필요합니다.",
+    NO_AUTHORITY: "권한이 없습니다.",
+    NO_OWNERSHIP: "작성자가 아니므로 작업할 수 없습니다.",
+    NOT_FOUND: "대상을 찾을 수 없습니다.",
+    DUPLICATED_ERROR: "이미 처리된 요청입니다.",
+    SERVER_ERROR: "서버 오류가 발생했습니다.",
+};

--- a/src/hooks/auth/useSignup.ts
+++ b/src/hooks/auth/useSignup.ts
@@ -38,5 +38,6 @@ export const useSignup = () => {
 
             return res.data;
         },
+        meta: { suppressGlobalError: true },
     });
 };

--- a/src/hooks/owner/review/useGetAllReviewsForGuesthouse.ts
+++ b/src/hooks/owner/review/useGetAllReviewsForGuesthouse.ts
@@ -6,4 +6,5 @@ export const useGetAllReviewsForGuesthouse = (reviewType: "ALL" | "COMMENTED") =
     useQuery<ReviewListItemProps>({
         queryKey: ["guesthouseReviews", reviewType],
         queryFn: () => ReviewApi.getAllReviewsForGuesthouse(reviewType),
+        meta: { suppressGlobalError: true },
     });

--- a/src/hooks/staff/useApplicationApply.ts
+++ b/src/hooks/staff/useApplicationApply.ts
@@ -7,5 +7,6 @@ export const useApplicationApply = () => {
             const { data } = await api.post("/apply", {}, { params: { employmentId } });
             return data;
         },
+        meta: { suppressGlobalError: true },
     });
 };

--- a/src/hooks/staff/useFetchMyApplication.ts
+++ b/src/hooks/staff/useFetchMyApplication.ts
@@ -25,5 +25,6 @@ export const useFetchMyApplication = () => {
             // 나머지는 최대 3번까지만 재시도
             return failureCount < 3;
         },
+        meta: { suppressGlobalError: true },
     });
 };

--- a/src/layout/AuthLayout.tsx
+++ b/src/layout/AuthLayout.tsx
@@ -2,11 +2,13 @@ import { Outlet } from "react-router-dom";
 import styled from "@emotion/styled";
 import PageWrapper from "@/components/PageWrapper";
 import SessionWatcher from "@/components/SessionWatcher";
+import ErrorWatcher from "@/components/ErrorWatcher";
 
 export default function AuthLayout() {
     return (
         <>
             <SessionWatcher />
+            <ErrorWatcher />
             <PageWrapper isRoot>
                 <ContentWrapper>
                     <Outlet />

--- a/src/layout/ChatLayout.tsx
+++ b/src/layout/ChatLayout.tsx
@@ -3,11 +3,13 @@ import styled from "@emotion/styled";
 import PageWrapper from "@/components/PageWrapper";
 import Nav from "@/components/Nav";
 import SessionWatcher from "@/components/SessionWatcher";
+import ErrorWatcher from "@/components/ErrorWatcher";
 
 export default function CommonLayout() {
     return (
         <>
             <SessionWatcher />
+            <ErrorWatcher />
             <PageWrapper hasNav>
                 <ContentWrapper>
                     <Outlet />

--- a/src/layout/FullScreenLayout.tsx
+++ b/src/layout/FullScreenLayout.tsx
@@ -4,6 +4,7 @@ import PageWrapper from "@/components/PageWrapper";
 import { useRef } from "react";
 import { useScrollToTopOnPathChange } from "@/hooks/useScrollToTopOnPathChange";
 import SessionWatcher from "@/components/SessionWatcher";
+import ErrorWatcher from "@/components/ErrorWatcher";
 
 export default function FullscreenLayout() {
     const contentRef = useRef<HTMLDivElement>(null);
@@ -11,6 +12,7 @@ export default function FullscreenLayout() {
     return (
         <>
             <SessionWatcher />
+            <ErrorWatcher />
             <PageWrapper isRoot>
                 <FullHeightContent ref={contentRef}>
                     <Outlet />

--- a/src/layout/OwnerLayout.tsx
+++ b/src/layout/OwnerLayout.tsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled";
 import { useRef } from "react";
 import { useScrollToTopOnPathChange } from "@/hooks/useScrollToTopOnPathChange";
 import SessionWatcher from "@/components/SessionWatcher";
+import ErrorWatcher from "@/components/ErrorWatcher";
 
 export default function OwnerLayout() {
     const contentRef = useRef<HTMLDivElement>(null);
@@ -12,6 +13,7 @@ export default function OwnerLayout() {
     return (
         <>
             <SessionWatcher />
+            <ErrorWatcher />
             <PageWrapper hasNav>
                 <ContentWrapper ref={contentRef}>
                     <Outlet />

--- a/src/layout/StaffLayout.tsx
+++ b/src/layout/StaffLayout.tsx
@@ -5,6 +5,7 @@ import styled from "@emotion/styled";
 import { useRef } from "react";
 import { useScrollToTopOnPathChange } from "@/hooks/useScrollToTopOnPathChange";
 import SessionWatcher from "@/components/SessionWatcher";
+import ErrorWatcher from "@/components/ErrorWatcher";
 
 export default function StaffLayout() {
     const contentRef = useRef<HTMLDivElement>(null);
@@ -12,6 +13,7 @@ export default function StaffLayout() {
     return (
         <>
             <SessionWatcher />
+            <ErrorWatcher />
             <PageWrapper hasNav>
                 <ContentWrapper ref={contentRef}>
                     <Outlet />

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,16 +5,15 @@ import theme from "./styles/theme.ts";
 import { ThemeProvider } from "@emotion/react";
 import { Global } from "@emotion/react";
 import { GlobalStyle } from "./styles/GlobalStyle.ts";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Capacitor } from "@capacitor/core";
 import { StatusBar, Style } from "@capacitor/status-bar";
+import { QueryClientProvider } from "@tanstack/react-query";
+import { queryClient } from "./apis/queryClient.ts";
 
 if (Capacitor.isNativePlatform()) {
     StatusBar.setOverlaysWebView({ overlay: true }); // 웹뷰가 상태바 밑으로 확장
     StatusBar.setStyle({ style: Style.Dark }); // 상태바 텍스트 색상
 }
-
-const queryClient = new QueryClient();
 
 createRoot(document.getElementById("root")!).render(
     <QueryClientProvider client={queryClient}>

--- a/src/pages/auth/BusinessVerification.tsx
+++ b/src/pages/auth/BusinessVerification.tsx
@@ -40,9 +40,6 @@ export default function BusinessVerificationPage() {
                     alert("사업자 인증이 완료되었습니다.");
                     navigate("/owner", { replace: true });
                 },
-                onError: () => {
-                    alert("사업자 인증 중 오류가 발생했습니다.");
-                },
             }
         );
     };

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -49,7 +49,7 @@ export default function SignupPage() {
 
     const signupMutation = useSignup();
 
-    type ModalType = "success" | "invalid_code" | "failure" | null;
+    type ModalType = "success" | "invalid_code" | null;
     const [modal, setModal] = useState<ModalType>(null);
 
     const handleSubmit = () => {
@@ -72,8 +72,6 @@ export default function SignupPage() {
                 onError: err => {
                     if (isAxiosError(err) && err.response?.status === 422) {
                         setModal("invalid_code"); // 인증번호 오류
-                    } else {
-                        setModal("failure"); // 기타 오류
                     }
                 },
             }
@@ -207,16 +205,6 @@ export default function SignupPage() {
                 />
             )}
 
-            {modal === "failure" && (
-                <Modal
-                    variant="error"
-                    title="회원가입에 실패했어요"
-                    message="잠시 후 다시 시도해 주세요."
-                    confirmText="확인"
-                    handleModalClose={() => setModal(null)}
-                    onConfirm={() => setModal(null)}
-                />
-            )}
         </>
     );
 }

--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -15,6 +15,7 @@ import { UserInfo } from "@/types/user";
 import { formatPhoneNumberKR } from "@/utils/formatPhoneNumberKR";
 import { isAxiosError } from "axios";
 import Modal from "@/components/Modal";
+import { errorMessages } from "@/constants/errorMessages";
 
 export default function SignupPage() {
     const { userInfo, errors, handleInputChange, validate } = useValidation();
@@ -49,7 +50,7 @@ export default function SignupPage() {
 
     const signupMutation = useSignup();
 
-    type ModalType = "success" | "invalid_code" | null;
+    type ModalType = "success" | "invalid_code" | "duplicate_nickname" | "server_error" | null;
     const [modal, setModal] = useState<ModalType>(null);
 
     const handleSubmit = () => {
@@ -70,8 +71,24 @@ export default function SignupPage() {
                     setModal("success");
                 },
                 onError: err => {
-                    if (isAxiosError(err) && err.response?.status === 422) {
-                        setModal("invalid_code"); // 인증번호 오류
+                    if (isAxiosError(err)) {
+                        const status = err.response?.status;
+                        const bodyStatus = err.response?.data?.status;
+
+                        // 422 인증번호 오류
+                        if (status === 422) {
+                            setModal("invalid_code");
+                            return;
+                        }
+
+                        // 409 닉네임 중복
+                        if (status === 409 || bodyStatus === "DUPLICATED_ERROR") {
+                            setModal("duplicate_nickname");
+                            return;
+                        }
+
+                        // 그 외 서버 오류
+                        setModal("server_error");
                     }
                 },
             }
@@ -198,13 +215,34 @@ export default function SignupPage() {
                 <Modal
                     variant="error"
                     title="인증번호가 올바르지 않아요"
-                    message={"입력한 인증번호를 확인해 주세요."}
+                    message="입력한 인증번호를 확인해 주세요."
                     confirmText="확인"
                     handleModalClose={() => setModal(null)}
                     onConfirm={() => setModal(null)}
                 />
             )}
 
+            {modal === "duplicate_nickname" && (
+                <Modal
+                    variant="error"
+                    title="이미 사용 중인 닉네임이에요"
+                    message="다른 닉네임으로 변경 후 다시 시도해 주세요."
+                    confirmText="확인"
+                    handleModalClose={() => setModal(null)}
+                    onConfirm={() => setModal(null)}
+                />
+            )}
+
+            {modal === "server_error" && (
+                <Modal
+                    variant="error"
+                    title="오류가 발생했어요"
+                    message={errorMessages[500]}
+                    confirmText="확인"
+                    handleModalClose={() => setModal(null)}
+                    onConfirm={() => setModal(null)}
+                />
+            )}
         </>
     );
 }

--- a/src/pages/owner/OwnerApplicationViewPage.tsx
+++ b/src/pages/owner/OwnerApplicationViewPage.tsx
@@ -29,14 +29,14 @@ export default function OwnerApplicationViewPage() {
     const [currentImageIndex, setCurrentImageIndex] = useState(0);
     const [tab, setTab] = useState<StaffTabTypes["MY_APPLICATION"]>("자기소개");
 
-    const { data: otherUserApplication, isLoading, isError } = useGetOtherUserApplication(targetUserId as number);
+    const { data: otherUserApplication, isLoading } = useGetOtherUserApplication(targetUserId as number);
 
     if (!Number.isFinite(targetUserId)) {
         return <div style={{ padding: 16 }}>잘못된 접근입니다.</div>;
     }
     if (isLoading) return <LoadingSpinner />;
-    if (isError || !otherUserApplication) {
-        return <div style={{ padding: 16 }}>지원서를 불러오지 못했습니다.</div>;
+    if (!otherUserApplication) {
+        return null;
     }
 
     const handleImageClick = (idx: number) => {

--- a/src/pages/staff/CategoryPage.tsx
+++ b/src/pages/staff/CategoryPage.tsx
@@ -19,7 +19,7 @@ export default function CategoryPage() {
     const label = params.get("label") || "";
     const category = categoryMap[label];
 
-    const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useEmploymentAll({
+    const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useEmploymentAll({
         type: sort === "마감공고" ? "END" : "IN_PROGRESS",
         category,
         pageSize: 6,
@@ -39,8 +39,6 @@ export default function CategoryPage() {
                 />
                 {isLoading ? (
                     <SkeletonList variant="guesthouse" count={5} />
-                ) : isError ? (
-                    <Oops message="에러가 발생했어요" description="다시 시도해주세요"></Oops>
                 ) : items.length === 0 ? (
                     <Wrapper.FlexBox gap="12px" alignItems="center" direction="column" padding="50% 0">
                         <Oops

--- a/src/pages/staff/HomePage.tsx
+++ b/src/pages/staff/HomePage.tsx
@@ -26,13 +26,13 @@ export default function HomePage() {
     const navigate = useNavigate();
     const [sort, setSort] = useState<SearchTab>("진행중인 공고");
 
-    const { data, isLoading, isError, fetchNextPage, hasNextPage, isFetchingNextPage } = useEmploymentAll({
+    const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } = useEmploymentAll({
         type: sort === "마감공고" ? "END" : "IN_PROGRESS",
         search: debouncedSearch || undefined,
         pageSize: 6,
         enabled: !!debouncedSearch,
     });
-    const { data: latest, isLoading: isLatestLoading, isError: isLatestError } = useEmploymentLatest(10);
+    const { data: latest, isLoading: isLatestLoading } = useEmploymentLatest(10);
 
     const setUser = useUserStore(s => s.setUser);
     const current = useUserStore(
@@ -106,8 +106,6 @@ export default function HomePage() {
                 <Section>
                     {isDebouncing || isLoading ? (
                         <SkeletonList variant="guesthouse" count={5} />
-                    ) : isError ? (
-                        <Oops message="에러가 발생했어요" description="다시 시도해주세요" />
                     ) : searchResults.length === 0 ? (
                         <>
                             <Wrapper.FlexBox
@@ -161,8 +159,6 @@ export default function HomePage() {
                         <SectionTitle title="새롭게 올라온 게스트하우스 🏡" link="/staff/guesthouse/latest" />
                         {isLatestLoading ? (
                             <SkeletonList variant="guesthouse" count={2} />
-                        ) : isLatestError ? (
-                            <Oops message="최신 공고를 불러오지 못했어요" description="잠시 후 다시 시도해주세요." />
                         ) : !latest || latest.length === 0 ? (
                             <Oops message="작성된 공고가 없어요" description="공고가 올라올 때까지 기다려주세요!" />
                         ) : (

--- a/src/pages/staff/LatestGuesthousePage.tsx
+++ b/src/pages/staff/LatestGuesthousePage.tsx
@@ -7,15 +7,13 @@ import { Wrapper } from "@/styles/Wrapper";
 import { SkeletonList } from "@/components/Skeleton/SkeletonList";
 
 export default function LatestGuesthousePage() {
-    const { data, isLoading, isError } = useEmploymentLatest(10);
+    const { data, isLoading } = useEmploymentLatest(10);
     return (
         <>
             <Header title="새로운 공고" showBackButton />
             <PageWrapper hasHeader>
                 {isLoading ? (
                     <SkeletonList variant="guesthouse" count={5} />
-                ) : isError ? (
-                    <Oops message="에러가 발생했어요" description="다시 시도해주세요" />
                 ) : !data || data.length === 0 ? (
                     <Wrapper.FlexBox gap="12px" alignItems="center" direction="column" padding="50% 0">
                         <Oops message="작성된 공고가 없어요." description="공고가 올라올 때까지 기다려주세요!" />

--- a/src/pages/staff/StaffApplicationViewPage.tsx
+++ b/src/pages/staff/StaffApplicationViewPage.tsx
@@ -57,11 +57,9 @@ export default function StaffApplicationViewPage() {
             },
             onError: err => {
                 const axiosErr = err as AxiosError;
+                setIsConfirmOpen(false);
                 if (axiosErr.response?.status === 409) {
-                    setIsConfirmOpen(false);
                     setIsAlreadyAppliedOpen(true);
-                } else {
-                    alert("지원에 실패했습니다. 잠시 후 다시 시도해주세요.");
                 }
             },
         });

--- a/src/pages/staff/user/EditProfilePage.tsx
+++ b/src/pages/staff/user/EditProfilePage.tsx
@@ -21,7 +21,7 @@ export default function EditProfilePage() {
     const [isEditMode, setIsEditMode] = useState(false);
     const setUser = useUserStore(state => state.setUser);
 
-    const { data: user, isLoading, isError } = useFetchUserProfile();
+    const { data: user, isLoading } = useFetchUserProfile();
     const updateMutation = useUpdateUserProfile();
     const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
     const [isCompleteModalOpen, setIsCompleteModalOpen] = useState(false);
@@ -93,7 +93,7 @@ export default function EditProfilePage() {
     };
 
     if (isLoading) return <div>불러오는 중...</div>;
-    if (isError || !user) return <div>사용자 정보를 불러오지 못했습니다.</div>;
+    if (!user) return null;
 
     const isPhoneChanged = userInfo.phone !== user.phone;
     const isVerificationRequired = isEditMode && isPhoneChanged;

--- a/src/store/useErrorStore.ts
+++ b/src/store/useErrorStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+
+interface ErrorState {
+    isOpen: boolean;
+    message: string;
+    showError: (message: string) => void;
+    clearError: () => void;
+}
+
+export const useErrorStore = create<ErrorState>(set => ({
+    isOpen: false,
+    message: "",
+    showError: message =>
+        set(state => {
+            if (state.isOpen && state.message === message) {
+                return state;
+            }
+            return {
+                isOpen: true,
+                message,
+            };
+        }),
+    clearError: () =>
+        set({
+            isOpen: false,
+            message: "",
+        }),
+}));


### PR DESCRIPTION
## 📝 작업 내용

> React Query 기반 API 호출의 에러 처리를 전역에서 통합 관리하도록 리팩토링
> 전역 에러 핸들러, 공통 메시지 상수, ErrorWatcher 컴포넌트를 구축하고  
> 이후 meta 기반 예외처리와 페이지 단의 중복 에러 제거 작업까지 단계적으로 진행

### 주요 변경사항
- **에러 메시지 상수 추가 (`errorMessages.ts`)**
  - HTTP 상태코드 및 백엔드 `response.status` 값을 기반으로 한 에러 메시지 상수 정의
  - 중복 메시지를 통합하고, 모든 API 응답 에러를 공통 포맷으로 관리할 수 있도록 구조화

- **전역 에러 핸들러 구축 (`queryClient.ts`)**
  - `QueryCache` / `MutationCache`의 `onError`를 통합하여 에러 발생 시 전역 모달을 호출하도록 개선
  - `getErrorMessage()` → `useErrorStore.showError()` 플로우로 모든 에러를 중앙에서 수집·관리
  - `QueryMetaFlags` 타입과 `meta.suppressGlobalError` 옵션 추가 —  로컬 전용 에러 UI가 필요한 쿼리/뮤테이션은 전역 모달에서 제외 가능

- **전역 에러 감시 컴포넌트 신규 구현 (`src/components/ErrorWatcher.tsx`)**
  - 전역 에러 발생 여부를 `useErrorStore`로 구독하고, 감지 시 공통 모달을 표시
  - 모달 확인 시 자동으로 에러 상태를 초기화(`clearError`)하며, 루트(`/`)로 복귀하도록 처리
  - `StaffLayout`, `OwnerLayout`, `AuthLayout` 등 주요 레이아웃에 전역 감시자로 삽입

- **페이지 및 훅 단위 정리**
  - `HomePage`, `CategoryPage`, `LatestGuesthousePage`, `EditProfilePage`, `OwnerApplicationViewPage` 등  
    단순한 `isError` 조건 및 Oops 처리 제거 → 전역 핸들러로 처리
  - `useSignup`, `useFetchMyApplication` 등 로컬 예외 UI가 필요한 훅은  
    `meta: { suppressGlobalError: true }` 설정으로 전역 모달 중복 방지

> 아직 전역 핸들러 세부 동작이나 로컬 에러 처리는 완성형은 아니며,  
> 비로그인 접근 허용 및 웹 최적화 작업 이후 우선순위에 따라 단계적으로 보완 예정입니다.

---

## 🌟 기대 효과

- 전역 ErrorWatcher를 통한 일관된 에러 메시징 확보
- 에러 처리 로직의 중복 제거 및 코드 간결화
- 로컬·전역 에러 핸들러 분리로 유지보수 및 확장성 개선
- 중복 에러 모달(전역 + 로컬) 문제를 해결하여 UX 혼란 해소
- 추후 에러 로깅/모니터링 시스템 연동 용이

---

## #️⃣ 해당 작업과 연관된 이슈

#104 

> 여러 차례 QA를 진행했으나, 일부 예외 구간이 남아 있을 수 있습니다,,,
> 발견되는 이슈가 있다면 코멘트로 공유 부탁드립니다 🥲